### PR TITLE
feat: campaign reload commands + cached room data refresh

### DIFF
--- a/Kepler-Server/src/main/java/org/alexdev/kepler/game/commandqueue/CommandQueueManager.java
+++ b/Kepler-Server/src/main/java/org/alexdev/kepler/game/commandqueue/CommandQueueManager.java
@@ -60,6 +60,12 @@ public class CommandQueueManager {
                 case BOT_TALK:
                     command = new BotTalkCommand();
                     break;
+                case RELOAD_CATALOGUE:
+                    command = new ReloadCatalogueCommand();
+                    break;
+                case RELOAD_NAVIGATOR:
+                    command = new ReloadNavigatorCommand();
+                    break;
                 default:
                     break;
             }

--- a/Kepler-Server/src/main/java/org/alexdev/kepler/game/commandqueue/CommandType.java
+++ b/Kepler-Server/src/main/java/org/alexdev/kepler/game/commandqueue/CommandType.java
@@ -15,7 +15,9 @@ public enum CommandType {
     TEST_PACKET("test_packet"),
     UPDATE_INFOBUS("update_infobus"),
     RESET_BOTS("reset_bots"),
-    BOT_TALK("bot_talk");
+    BOT_TALK("bot_talk"),
+    RELOAD_CATALOGUE("reload_catalogue"),
+    RELOAD_NAVIGATOR("reload_navigator");
 
     private final String commandName;
 

--- a/Kepler-Server/src/main/java/org/alexdev/kepler/game/commandqueue/commands/ReloadCatalogueCommand.java
+++ b/Kepler-Server/src/main/java/org/alexdev/kepler/game/commandqueue/commands/ReloadCatalogueCommand.java
@@ -1,0 +1,23 @@
+package org.alexdev.kepler.game.commandqueue.commands;
+
+import org.alexdev.kepler.game.catalogue.CatalogueManager;
+import org.alexdev.kepler.game.commandqueue.CommandTemplate;
+import org.alexdev.kepler.game.item.ItemManager;
+import org.alexdev.kepler.game.player.Player;
+import org.alexdev.kepler.game.player.PlayerManager;
+import org.alexdev.kepler.messages.outgoing.catalogue.CATALOGUE_PAGES;
+import org.alexdev.kepler.messages.outgoing.catalogue.REFRESH_CATALOGUE;
+
+public class ReloadCatalogueCommand implements Command {
+    public void executeCommand(CommandTemplate commandArgs) {
+        ItemManager.reset();
+        CatalogueManager.reset();
+
+        for (Player p : PlayerManager.getInstance().getPlayers()) {
+            p.send(new CATALOGUE_PAGES(
+                    CatalogueManager.getInstance().getPagesForRank(p.getDetails().getFuseRights(), p.getDetails().hasClubSubscription())
+            ));
+            p.send(new REFRESH_CATALOGUE());
+        }
+    }
+}

--- a/Kepler-Server/src/main/java/org/alexdev/kepler/game/commandqueue/commands/ReloadNavigatorCommand.java
+++ b/Kepler-Server/src/main/java/org/alexdev/kepler/game/commandqueue/commands/ReloadNavigatorCommand.java
@@ -1,0 +1,30 @@
+package org.alexdev.kepler.game.commandqueue.commands;
+
+import org.alexdev.kepler.dao.mysql.RoomDao;
+import org.alexdev.kepler.game.commandqueue.CommandTemplate;
+import org.alexdev.kepler.game.navigator.NavigatorManager;
+import org.alexdev.kepler.game.room.Room;
+import org.alexdev.kepler.game.room.RoomManager;
+
+public class ReloadNavigatorCommand implements Command {
+    public void executeCommand(CommandTemplate commandArgs) {
+        // Re-sync cached public room data (name/description/ccts) from the database so
+        // campaign changes to these fields take effect without a server restart. Rooms
+        // not yet cached are loaded fresh from the DB on next access, so only the
+        // already-loaded public rooms need refreshing here.
+        for (Room room : RoomManager.getInstance().getRooms()) {
+            if (!room.isPublicRoom()) {
+                continue;
+            }
+
+            Room fresh = RoomDao.getRoomById(room.getId());
+            if (fresh != null) {
+                room.getData().setName(fresh.getData().getName());
+                room.getData().setDescription(fresh.getData().getDescription());
+                room.getData().setCcts(fresh.getData().getCcts());
+            }
+        }
+
+        NavigatorManager.getInstance().resetCategoryMap();
+    }
+}

--- a/Kepler-Server/src/main/java/org/alexdev/kepler/game/fuserights/Fuse.java
+++ b/Kepler-Server/src/main/java/org/alexdev/kepler/game/fuserights/Fuse.java
@@ -57,7 +57,8 @@ public enum Fuse {
         //EDIT_CATALOGUE("fuse_catalog_editor"), // Not used
         GIVE_CREDITS("fuse_give_credits"),
         BADGES("fuse_badges"),
-        BOTS("fuse_bots");
+        BOTS("fuse_bots"),
+        CAMPAIGNS("fuse_campaigns");
 
         private final String fuseName;
 


### PR DESCRIPTION
Server-side support for the CMS campaign system, driven over RabbitMQ:
- Add RELOAD_CATALOGUE and RELOAD_NAVIGATOR command-queue types and wire them into CommandQueueManager.
- ReloadCatalogueCommand resets ItemManager/CatalogueManager and re-pushes catalogue pages to online players.
- ReloadNavigatorCommand re-syncs cached public room name/description/ccts from the database so campaign room changes take effect without a restart, then resets the navigator category map.
- Add CAMPAIGNS("fuse_campaigns") fuseright.